### PR TITLE
PoC Dockerization of Fork CMS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,8 @@ app/cache/*
 app/config/parameters.yml
 build/*
 !build/docker/*
-src/Backend/Cache/*
-src/Frontend/Cache/*
+src/Backend/Cache/*/*
+src/Frontend/Cache/*/*
 deploy/*
 gulp/*
 node_modules/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.idea
+app/logs/*
+app/cache/*
+build/*
+!build/docker/*
+deploy/*
+gulp/*
+node_modules/*
+scripts/*
+test*/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,14 @@
 .idea
 app/logs/*
 app/cache/*
+app/config/parameters.yml
 build/*
 !build/docker/*
+src/Backend/Cache/*
+src/Frontend/Cache/*
 deploy/*
 gulp/*
 node_modules/*
 scripts/*
 test*/*
+vendor/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ build/*
 !build/docker/*
 src/Backend/Cache/*/*
 src/Frontend/Cache/*/*
+src/Frontend/Files/*
 deploy/*
 gulp/*
 node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Libraries
 /vendor/*
 
+# Docker
+/data/*
+
 # Generated files
 .project
 .cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM php:7.0-apache
 MAINTAINER Fork CMS <info@fork-cms.com>
 
-COPY . /var/www/html/
-RUN chown -R www-data:www-data /var/www/html/
-
 # Install MCrypt
 RUN apt-get update \
     && apt-get install -y libmcrypt-dev \
@@ -28,3 +25,15 @@ ENV APACHE_DOC_ROOT /var/www/html
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
+
+# Bundle source code
+COPY . /var/www/html/
+
+# Install app dependencies
+RUN cd /var/www/html && /usr/local/bin/composer install --optimize-autoloader --prefer-dist --no-dev --no-interaction --no-scripts
+
+# Give apache write access to host
+RUN chown -R www-data:www-data /var/www/html/
+
+EXPOSE 80
+EXPOSE 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:7.0-apache
+MAINTAINER Fork CMS <info@fork-cms.com>
+
+COPY . /var/www/html/
+RUN chown -R www-data:www-data /var/www/html/
+
+# Install MCrypt
+RUN apt-get update \
+    && apt-get install -y libmcrypt-dev \
+    && docker-php-ext-install mcrypt
+
+# Install Intl
+RUN apt-get update \
+    && apt-get install -y libicu-dev \
+    && docker-php-ext-install intl
+
+# Install PHP extensions: GD, mbstring, mysql, pdo, zip
+RUN apt-get update && apt-get install -y unzip libpng12-dev libjpeg-dev libpq-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+	&& docker-php-ext-install gd mbstring mysqli pdo pdo_mysql zip
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+# Configure Apache Document Root
+ENV APACHE_DOC_ROOT /var/www/html
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,34 @@
 FROM php:7.0-apache
 MAINTAINER Fork CMS <info@fork-cms.com>
 
-# Install MCrypt
-RUN apt-get update \
-    && apt-get install -y libmcrypt-dev \
-    && docker-php-ext-install mcrypt
-
-# Install Intl
-RUN apt-get update \
-    && apt-get install -y libicu-dev \
-    && docker-php-ext-install intl
-
-# Install PHP extensions: GD, mbstring, mysql, pdo, zip
-RUN apt-get update && apt-get install -y unzip libpng12-dev libjpeg-dev libpq-dev \
-	&& rm -rf /var/lib/apt/lists/* \
+# Install the PHP extensions we need
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev libicu-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mbstring mysqli pdo pdo_mysql zip
+	&& docker-php-ext-install gd mysqli opcache mcrypt intl mbstring pdo pdo_mysql zip
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
-
-# Configure Apache Document Root
-ENV APACHE_DOC_ROOT /var/www/html
+# Set recommended PHP.ini settings
+# See https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Configure Apache Document Root
+ENV APACHE_DOC_ROOT /var/www/html
+
 # Bundle source code
 COPY . /var/www/html/
 
-# Install app dependencies
+# Install composer and install the app dependencies
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 RUN cd /var/www/html && /usr/local/bin/composer install --optimize-autoloader --prefer-dist --no-dev --no-interaction --no-scripts
 
 # Give apache write access to host
 RUN chown -R www-data:www-data /var/www/html/
-
-EXPOSE 80
-EXPOSE 443

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,12 +8,13 @@ services:
             - "80:80"
             - "443:443"
         volumes:
-            - ./data/files:/var/www/html:rw
+            - ./data/config/parameters.yml:/var/www/html/app/config/parameters.yml:rw
+            - ./data/files:/var/www/html/src/Frontend/Files:rw
         links:
             - db
         environment:
-            - FORK_DEBUG=1
-            - FORK_ENV=dev
+            - FORK_DEBUG=0
+            - FORK_ENV=prod
 
     db:
         image: mariadb

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,12 +9,14 @@ services:
             - "443:443"
         volumes:
             - ./data/config/parameters.yml:/var/www/html/app/config/parameters.yml:rw
-            - ./data/files:/var/www/html/src/Frontend/Files:rw
+            - ./data/logs/:/var/www/html/app/logs:rw
+            - ./data/files/:/var/www/html/src/Frontend/Files:rw
         links:
             - db
         environment:
             - FORK_DEBUG=0
             - FORK_ENV=prod
+        entrypoint: ./tools/docker-entrypoint.sh
 
     db:
         image: mariadb

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,8 +19,6 @@ services:
     db:
         image: mariadb
         restart: always
-        ports:
-            - '3306:3306'
         environment:
             - MYSQL_DATABASE=fork_cms
             - MYSQL_USER=fork_cms_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             - "80:80"
             - "443:443"
         volumes:
-            - ./data/files:/var/www/html:rw
+            - .:/var/www/html:rw
         links:
             - db
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ services:
     web:
         build: .
         working_dir: /var/www/html
+        restart: always
         ports:
             - "80:80"
             - "443:443"
-        # volumes:
-        #     - /data/config/parameters.yml:/var/www/html/app/config/parameters.yml
-        #     - /data/files:/var/www/html/src/Frontend/Files
+        volumes:
+            - ./data/config/parameters.yml:/var/www/html/app/config/parameters.yml:rw
+            - ./data/files:/var/www/html/src/Frontend/Files:rw
         links:
             - db
         environment:
@@ -17,6 +18,7 @@ services:
 
     db:
         image: mariadb
+        restart: always
         ports:
             - '3306:3306'
         environment:
@@ -25,4 +27,4 @@ services:
             - MYSQL_PASSWORD=fork_cms_password
             - MYSQL_ROOT_PASSWORD=fork_cms_root
         volumes:
-            - /data/db/databases:/var/lib/mysql:rw
+            - ./data/db/databases:/var/lib/mysql:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+    web:
+        build: .
+        ports:
+            - "80:80"
+            - "443:443"
+        volumes:
+            - .:/var/www/html
+        links:
+            - db
+
+    db:
+        image: mariadb
+        ports:
+            - '3306:3306'
+        environment:
+            - MYSQL_DATABASE=fork_cms
+            - MYSQL_USER=fork_cms_user
+            - MYSQL_PASSWORD=fork_cms_password
+            - MYSQL_ROOT_PASSWORD=fork_cms_root
+        volumes:
+            - ./data/db/databases:/var/lib/mysql:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,18 @@ version: '2'
 services:
     web:
         build: .
+        working_dir: /var/www/html
         ports:
             - "80:80"
             - "443:443"
-        volumes:
-            - .:/var/www/html
+        # volumes:
+        #     - /data/config/parameters.yml:/var/www/html/app/config/parameters.yml
+        #     - /data/files:/var/www/html/src/Frontend/Files
         links:
             - db
+        environment:
+            - FORK_DEBUG=1
+            - FORK_ENV=prod
 
     db:
         image: mariadb
@@ -20,4 +25,4 @@ services:
             - MYSQL_PASSWORD=fork_cms_password
             - MYSQL_ROOT_PASSWORD=fork_cms_root
         volumes:
-            - ./data/db/databases:/var/lib/mysql:rw
+            - /data/db/databases:/var/lib/mysql:rw

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Chown the directories used by Apache to have the correct permissions
+chown -R www-data:www-data /var/www/html
+chown -R www-data:www-data ./data
+
+# Run apache server
+apache2-foreground


### PR DESCRIPTION
Basic dockerization of forkcms, using docker for Mac preferably. 

What?
- [x] Running PHP7, Apache and MariaDB (the preferred setup afaik)
- [x] Succesfully access Fork CMS through http://127.0.0.1:80 with all installed php extensions etc.
- [x] Push code in docker image + build with composer.
- [x] Switching between dev/prod? Use volumes for dev, copy for production
- [ ] Switching between dev/prod? Use xDebug only when env variables say it should be enabled.
- [x] Speed up building? --> use more layering
- [x] Find best way to deploy websites with docker? With no risk of data-loss. Just plain docker-compose and docker-machine? --> yeah seems like so
- [ ] Security? --> https://quay.io can help.
- [x] Docker compose mounts as root, instead of www-data?
- [ ] gzip support in apache?
- [ ] `./data` as volume means that the server will have this path `/Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/data/config/parameters.yml`??
- [x] Speed up tip: "Having Composer install all its dependencies on every build is not ideal." 
  http://sentinelstand.com/article/composer-install-in-dockerfile-without-breaking-cache
